### PR TITLE
service addresses minor fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ function Wrapper(network, baseURL) {
     // er ekki uppfærður 
     // Use skodari.broslaugin.com for testing while
     // main block explorer has not been updated
-    //baseURL = baseURL || 'https://blocks.smileyco.in/api/';
-    baseURL = baseURL || 'https://skodari.broslaugin.com/api/';
+    baseURL = baseURL || 'https://blocks.smileyco.in/api/';
+    //baseURL = baseURL || 'https://skodari.broslaugin.com/api/';
 
     // end points
     this.addresses = new Addresses(baseURL);


### PR DESCRIPTION
Changed the default block explorer from skodari.broslaugin.com to blocks.smileyco.in. 
Use skodari.broslaugin.com to test service addresses